### PR TITLE
Updated the logical error in stack.c code 

### DIFF
--- a/stack.c
+++ b/stack.c
@@ -39,7 +39,7 @@ int pop()
     {
         int out;
         out=st.arr[st.top];
-        st.top++;
+        st.top--;
         return out;
     }
 }


### PR DESCRIPTION
# There was a logical error 
- In the code if we attempt to display for the best case then the all elements would be displayed
-  but when we talk about the worst case when the elements are poped after pushing then only remaining elements should be displayed, but it displays the poped ones too along with extra zeros.
- So this is the updated code for the same so that the memory of the pop element would be available for the next elements if pushed & the above error is fixed. 
**Hope this finds great  & it would be very much great if you accept my pull request.**